### PR TITLE
[PLAT-1756] Expose available runner count on metrics query

### DIFF
--- a/lib/flame/pool.ex
+++ b/lib/flame/pool.ex
@@ -512,7 +512,8 @@ defmodule FLAME.Pool do
       runner_count: runner_count(state),
       waiting_count: waiting_count(state),
       pending_count: pending_count(state),
-      desired_count: desired_count(state)
+      desired_count: desired_count(state),
+      available_count: available_runners_count(state)
     }
 
     {:reply, metrics, state}
@@ -546,6 +547,12 @@ defmodule FLAME.Pool do
   def desired_count(state) do
     {strategy_module, strategy_opts} = state.strategy
     strategy_module.desired_count(state, strategy_opts)
+  end
+
+  def available_runners_count(state) do
+    {strategy_module, strategy_opts} = state.strategy
+    runners = strategy_module.available_runners(state, strategy_opts)
+    Enum.count(runners)
   end
 
   defp replace_caller(%Pool{} = state, checkout_ref, caller_pid, [_ | _] = child_pids) do

--- a/lib/flame/pool/per_runner_max_concurrency_strategy.ex
+++ b/lib/flame/pool/per_runner_max_concurrency_strategy.ex
@@ -72,7 +72,7 @@ defmodule FLAME.Pool.PerRunnerMaxConcurrencyStrategy do
 
   @impl true
   def available_runners(state, _opts) do
-    state.runners
+    Enum.map(state.runners, fn {_ref, runner} -> runner end)
   end
 
   defp min_runner(pool) do

--- a/lib/flame/pool/strategy.ex
+++ b/lib/flame/pool/strategy.ex
@@ -24,4 +24,7 @@ defmodule FLAME.Pool.Strategy do
   @callback desired_count(state :: Pool.t(), opts :: Keyword.t()) :: non_neg_integer()
 
   @callback has_unmet_servicable_demand?(state :: Pool.t(), opts :: Keyword.t()) :: boolean()
+
+  @callback available_runners(state :: Pool.t(), opts :: Keyword.t()) ::
+              list(Pool.RunnerState.t())
 end


### PR DESCRIPTION
- **Add available_runners/2 to the strategy**
- **Expose the pool available count in metrics query**
