### PR TITLE
Tuning the pool to reduce sync blocking

### DIFF
--- a/lib/flame/pool.ex
+++ b/lib/flame/pool.ex
@@ -522,7 +522,6 @@ defmodule FLAME.Pool do
       runner_count: runner_count(state),
       waiting_count: waiting_count(state),
       pending_count: pending_count(state),
-      desired_count: desired_count(state),
       available_count: available_runners_count(state),
       min: state.min,
       max: state.max

--- a/lib/flame/pool.ex
+++ b/lib/flame/pool.ex
@@ -532,15 +532,7 @@ defmodule FLAME.Pool do
 
   @impl true
   def handle_call({:poll_unmet_demand, :scale}, _from, state) do
-    {strategy_module, strategy_opts} = state.strategy
-
-    state =
-      if strategy_module.has_unmet_servicable_demand?(state, strategy_opts) do
-        async_boot_runner(state)
-      else
-        state
-      end
-
+    state = async_boot_runner(state)
     {:reply, :ok, state}
   end
 

--- a/lib/flame/pool.ex
+++ b/lib/flame/pool.ex
@@ -892,22 +892,20 @@ defmodule FLAME.Pool do
         %{} -> state
       end
 
-    state =
-      case pending_runners do
-        %{^ref => _} ->
-          %Pool{state | pending_runners: Map.delete(state.pending_runners, ref)}
-
-        %{} ->
+    case pending_runners do
+      %{^ref => _} ->
+        state = %Pool{state | pending_runners: Map.delete(state.pending_runners, ref)}
+        # we rate limit this to avoid many failed async boot attempts
+        if strategy_module.has_unmet_servicable_demand?(state, strategy_opts) do
           state
-      end
+          |> maybe_on_grow_end(pid, {:exit, reason})
+          |> schedule_async_boot_runner()
+        else
+          maybe_on_grow_end(state, pid, {:exit, reason})
+        end
 
-    if strategy_module.has_unmet_servicable_demand?(state, strategy_opts) do
-      # we rate limit this to avoid many failed async boot attempts
-      state
-      |> maybe_on_grow_end(pid, {:exit, reason})
-      |> schedule_async_boot_runner()
-    else
-      maybe_on_grow_end(state, pid, {:exit, reason})
+      %{} ->
+        state
     end
   end
 


### PR DESCRIPTION
- **Revert "Scale the runners on :DOWN runner even if there are no pending runners"**
- **Don't expose desired_count on metrics query**
- **Don't double poll desired_count when external scaler polls the pool**
- **Improve syntax on async_boot_runner**
