### PR TITLE
Don't raise when checking a non-existent runner back into the flame pool

### DIFF
--- a/lib/flame/pool.ex
+++ b/lib/flame/pool.ex
@@ -637,8 +637,8 @@ defmodule FLAME.Pool do
         maybe_drop_waiting(state, caller_pid)
 
       %{} ->
-        raise ArgumentError,
-              "expected to checkin runner for #{inspect(caller_pid)} that does not exist"
+        Logger.info("Runner: #{inspect(caller_pid)}, went away -- maybe its draining")
+        state
     end
   end
 


### PR DESCRIPTION
We discovered an issue in SV after adding draining logic to drain running streams before shutting down a runner. What we noticed is that after every stream it would crash the FLAME pool running on the coordinator. In testing, what we noticed is that when the runner node is disconnected from the coordinator (for any reason) the internals of FLAME would capture that, send a "cancel" message to the pool at which point it would try to check in the runner, however, the runner had already been cleaned up from the pool's internal state. This was triggering the raise which is being removed in this PR.
